### PR TITLE
fix(config): validate if ports are conflict

### DIFF
--- a/pkg/endpoint/config.go
+++ b/pkg/endpoint/config.go
@@ -111,7 +111,11 @@ func (c *Config) Validate() error {
 	}
 
 	if c.PeerPort == 0 || c.PeerPort == c.Port {
-		return fmt.Errorf("invalid peer port %d", c.Port)
+		return fmt.Errorf("invalid peer port %d", c.PeerPort)
+	}
+
+	if c.InfoPort != 0 && (c.InfoPort == c.Port || c.InfoPort == c.PeerPort) {
+		return fmt.Errorf("invalid info port %d", c.InfoPort)
 	}
 
 	klog.InfoS("validate client security config", c.ClientSecurityConfig.ToKvs()...)


### PR DESCRIPTION
#### What type of PR is this?
Bug Fix

#### What this PR does / why we need it:
If ports are duplicated, KubeBrain process will run, listen some ports and then crash down. It is confusing for external component who check if KubeBrain process is healthy through HTTP or GRPC request.
#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
None