### PR TITLE
feat(backend): add flag to config watch cache size

### DIFF
--- a/cmd/option/option.go
+++ b/cmd/option/option.go
@@ -48,6 +48,8 @@ type KubeBrainOption struct {
 	storageConfig *storageConfig
 
 	EnableStorageMetrics bool
+
+	watchCacheSize int
 }
 
 func NewOptions() *KubeBrainOption {
@@ -59,9 +61,10 @@ func NewOptions() *KubeBrainOption {
 			PeerSecurityConfig:      &endpoint.SecurityConfig{},
 			EnableEtcdCompatibility: false,
 		},
-		Prefix:        "",
-		ClusterName:   "default",
-		storageConfig: newStorageConfig(),
+		Prefix:         "",
+		ClusterName:    "default",
+		storageConfig:  newStorageConfig(),
+		watchCacheSize: 200 * 1000,
 	}
 }
 
@@ -101,6 +104,7 @@ func (o *KubeBrainOption) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&o.EnableStorageMetrics, "enable-storage-metrics", o.EnableStorageMetrics, "enable storage metrics.")
 	o.storageConfig.addFlag(fs)
+	fs.IntVar(&o.watchCacheSize, "watch-cache-size", o.watchCacheSize, "size of global watch cache")
 }
 
 // Validate checks the option before running
@@ -148,6 +152,7 @@ func (o *KubeBrainOption) Run(ctx context.Context) error {
 		Identity:                identity,
 		SkippedPrefixes:         o.SkippedPrefixes,
 		EnableEtcdCompatibility: o.epsConf.EnableEtcdCompatibility,
+		WatchCacheSize:          o.watchCacheSize,
 	}
 
 	if o.EnableStorageMetrics {

--- a/pkg/backend/util.go
+++ b/pkg/backend/util.go
@@ -42,12 +42,18 @@ const (
 	unaryRpcTimeout = 1 * time.Second
 )
 
-func (c Config) getScannerConfig() scanner.Config {
+func (c *Config) getScannerConfig() scanner.Config {
 	// todo: expose TTL as args
 	return scanner.Config{
 		CompactKey: getCompactKey(c.Prefix),
 		Tombstone:  tombStoneBytes,
 		TTL:        time.Second * time.Duration(eventsTTL),
+	}
+}
+
+func (c *Config) complete() {
+	if c.WatchCacheSize <= 0 {
+		c.WatchCacheSize = historyCapacity
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
Features

#### What this PR does / why we need it:
add flag to config watch cache size. It will be helpful for 
- limit memory usage
- ensure that apiservers can watch successfully if cluster is very large 

#### Which issue(s) this PR fixes:
None
#### Special notes for your reviewer:
None