### PR TITLE
fix etcd watch cancel update metrics crash

### DIFF
--- a/pkg/server/etcd/watch.go
+++ b/pkg/server/etcd/watch.go
@@ -17,6 +17,7 @@ package etcd
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -159,9 +160,7 @@ func (w *watcher) Start(c context.Context, r *etcdserverpb.WatchCreateRequest) {
 func (w *watcher) Cancel(id int64, err error, compact bool) {
 	klog.InfoS("watch cancel", "watcher", w.id, "watch", id, "err", err, "compact", compact)
 	var tags []metrics.T
-	if compact {
-		tags = append(tags, metrics.Tag("compact", "true"))
-	}
+	tags = append(tags, metrics.Tag("compact", strconv.FormatBool(compact)))
 	w.metricCli.EmitCounter("watch.cancel", 1, tags...)
 	w.Lock()
 	if c, ok := w.watches[id]; ok {


### PR DESCRIPTION
#### What type of PR is this?
Bug fixes

#### What this PR does / why we need it:
Fix kubebrain crash when etcd watch cancel update metrics.

Detail: The watch.cancel indicator has a label. When two label values ​​are received, the prometheus library will crash.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None
