### PR TITLE
ci(lint): pin lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
+          version: v1.50.1
           file: ./coverage.out


### PR DESCRIPTION
Change-Id: I1892319b217b6ccca8483a0d94c38457f3cc5742

#### What type of PR is this?
<!--
Features/Bug fixes/enhancements
-->
Bug fixes

#### What this PR does / why we need it:

Pin golangci lint version to avoid warning

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
