### PR TITLE
chore: Replace deprecation ioutil functions

### DIFF
--- a/pkg/backend/range.go
+++ b/pkg/backend/range.go
@@ -79,7 +79,8 @@ func (b *backend) getLatestInternalVal(ctx context.Context, key []byte) (val []b
 
 // get returns the user-visible value and the revision it's modified with.
 // NOTICE: return storage.ErrKeyNotFound if the value is not exist or is a tombstone.
-//         modRevision maybe non-zero even if there is a storage.ErrKeyNotFound.
+//
+//	modRevision maybe non-zero even if there is a storage.ErrKeyNotFound.
 func (b *backend) get(ctx context.Context, key []byte, revision uint64) (val []byte, modRevision uint64, err error) {
 	val, modRevision, err = b.getInternalVal(ctx, key, revision)
 	if bytes.Compare(val, tombStoneBytes) == 0 {

--- a/pkg/endpoint/config.go
+++ b/pkg/endpoint/config.go
@@ -18,7 +18,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"sync"
 
@@ -200,7 +200,7 @@ func (sc *SecurityConfig) init() (err error) {
 		// load ca file
 		if sc.CA != "" {
 			certPool := x509.NewCertPool()
-			caFileBytes, err := ioutil.ReadFile(sc.CA)
+			caFileBytes, err := os.ReadFile(sc.CA)
 			if err != nil {
 				klog.ErrorS(err, "can not load ca cert", "ca", sc.CA)
 				sc.err = errors.Wrapf(err, "can not load ca cert")

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -16,7 +16,7 @@ package endpoint
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -96,7 +96,7 @@ func TestRunEndpoint(t *testing.T) {
 		t.Logf("testing url %s", url)
 		resp, err := http.Get(url)
 		ast.NoError(err)
-		bs, err := ioutil.ReadAll(resp.Body)
+		bs, err := io.ReadAll(resp.Body)
 		ast.NoError(err)
 		ast.Equal(server.HealthResponse, string(bs))
 		resp.Body.Close()

--- a/pkg/server/service/revision/revision.go
+++ b/pkg/server/service/revision/revision.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
@@ -241,7 +240,7 @@ func (r *revisionSyncer) getRevisionFromLeader() (uint64, error) {
 		return 0, fmt.Errorf("status code from leader %s is %d, msg is %s", leaderAddress, response.StatusCode, msg)
 	}
 
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/util/auth/testutil.go
+++ b/pkg/util/auth/testutil.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -36,7 +36,7 @@ func GetTLSConfig(certFile, keyFile, ca string) (tlsConfig *tls.Config, err erro
 
 	// load ca file
 	certPool := x509.NewCertPool()
-	caFileBytes, err := ioutil.ReadFile(ca)
+	caFileBytes, err := os.ReadFile(ca)
 	if err != nil {
 		klog.ErrorS(err, "can not load ca cert", "ca", ca)
 		return nil, errors.Wrapf(err, "can not load ca cert")

--- a/pkg/util/net_test.go
+++ b/pkg/util/net_test.go
@@ -16,7 +16,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -119,7 +119,7 @@ func testGetHostAndTestConn(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	got, _ := ioutil.ReadAll(resp.Body)
+	got, _ := io.ReadAll(resp.Body)
 	t.Log("got", string(got))
 	ast.Equal(msg, got)
 	_ = svr.Close()


### PR DESCRIPTION
#### What type of PR is this?
<!--
Features/Bug fixes/enhancements
-->

#### What this PR does / why we need it:

Go 1.16 deprecated several io/ioutil functions.

```
ioutil.ReadFile -> os.ReadFile
ioutil.ReadAll -> io.ReadAll
ioutil.ReadDir -> os.ReadDir
```

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
